### PR TITLE
Refactoring the Test setup 

### DIFF
--- a/node-runner-cli/github/github.py
+++ b/node-runner-cli/github/github.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 
 import requests
@@ -6,12 +7,21 @@ from utils.utils import Helpers
 
 
 def latest_release(repo_name="radixdlt/radixdlt"):
+    if repo_name == "radixdlt/babylon-nginx":
+        return os.environ.get('RADIXDTL_OVERRIDE_NGINX_VERSION')
+    if repo_name == "radixdlt/babylon-nodecli":
+        return os.environ.get('RADIXDTL_OVERRIDE_CLI_VERSION')
+    if repo_name == "radixdlt/babylon-gateway":
+        return os.environ.get('RADIXDTL_OVERRIDE_GATEWAY_VERSION')
+
+    token = os.environ.get('GITHUB_TOKEN', 'token notvalid')
     req = requests.Request('GET',
                            f'https://api.github.com/repos/{repo_name}/releases/latest')
 
     prepared = req.prepare()
     prepared.headers['Content-Type'] = 'application/json'
     prepared.headers['user-agent'] = 'radixnode-cli'
+    prepared.headers['Authorization'] = token
     resp = Helpers.send_request(prepared, print_response=False)
     if not resp.ok:
         print("Failed to get latest release from github. Exitting the command...")

--- a/node-runner-cli/radixnode.py
+++ b/node-runner-cli/radixnode.py
@@ -7,7 +7,6 @@ from argparse import ArgumentParser
 import urllib3
 
 from api.DefaultApiHelper import DefaultApiHelper
-from commands import othercommands
 from commands.authcommand import authcli
 from commands.coreapi import handle_core
 from commands.dockercommand import dockercli
@@ -18,7 +17,6 @@ from commands.systemapi import handle_systemapi
 from commands.systemdcommand import systemdcli
 from env_vars import DISABLE_VERSION_CHECK
 from github.github import latest_release
-from setup import Base
 from utils.utils import Helpers
 
 urllib3.disable_warnings()
@@ -52,8 +50,7 @@ def check_latest_cli():
                 """)
 
 
-if __name__ == "__main__":
-
+def main():
     args = cli.parse_args(sys.argv[1:2])
 
     if args.subcommand is None:
@@ -117,3 +114,7 @@ if __name__ == "__main__":
 
     else:
         print(f"Invalid subcommand {args.subcommand}")
+
+
+if __name__ == "__main__":
+    main()

--- a/node-runner-cli/tests/test_docker_command.py
+++ b/node-runner-cli/tests/test_docker_command.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from radixnode import main
+
+
+class DockerCommandTests(unittest.TestCase):
+    def test_docker_config_core(capsys):
+        os.environ['PROMPT_FEEDS'] = "test-prompts/core-gateway-all-local.yml"
+        with patch("sys.argv", ["main", "docker", "config", "-m", "DETAILED", "-k", "dummypassword", "-a", "-nk"]):
+            main()
+
+
+
+if __name__ == '__main__':
+    unittest.main(warnings='ignore')

--- a/node-runner-cli/tests/test_latest_release.py
+++ b/node-runner-cli/tests/test_latest_release.py
@@ -1,0 +1,71 @@
+import os
+import unittest
+
+from github.github import latest_release
+
+
+# fill with valid token
+token = "token <GH-TOKEN>"
+
+
+class GitHubTests(unittest.TestCase):
+
+    def legacy_test_latest_release(self):
+        latest_release()
+
+    def legacy_test_latest_release_nginx(self):
+        latest_release("radixdlt/radixdlt-nginx")
+
+    def legacy_test_latest_release_nodecli(self):
+        latest_release("radixdlt/node-runner")
+
+    def legacy_test_latest_release_gateway(self):
+        latest_release("radixdlt/radixdlt-network-gateway")
+
+    @unittest.skip("Waiting for first release in repo")
+    def test_latest_release_node_with_auth(self):
+        os.environ['GITHUB_TOKEN'] = token
+        latest_release("radixdlt/babylon-node")
+
+    def test_latest_release_nodecli_auth(self):
+        os.environ['GITHUB_TOKEN'] = token
+        latest_release("radixdlt/babylon-nodecli")
+
+    def test_latest_release_nginx_with_auth(self):
+        os.environ['GITHUB_TOKEN'] = token
+        latest_release("radixdlt/babylon-nginx")
+
+    def test_latest_release_nginx_environment_variable(self):
+        os.environ['RADIXDTL_OVERRIDE_NGINX_VERSION'] = '1.3.3'
+        version = latest_release("radixdlt/babylon-nginx")
+        self.assertEqual(version, '1.3.3')
+
+    def test_latest_release_cli_environment_variable(self):
+        os.environ['RADIXDTL_OVERRIDE_CLI_VERSION'] = '1.3.3'
+        version = latest_release("radixdlt/babylon-nodecli")
+        self.assertEqual(version, '1.3.3')
+
+    def test_latest_release_gateway_environment_variable(self):
+        os.environ['RADIXDTL_OVERRIDE_GATEWAY_VERSION'] = '1.3.3'
+        version = latest_release("radixdlt/babylon-nodecli")
+        self.assertEqual(version, '1.3.3')
+
+    @unittest.skip("This test is temporary until the repository goes public. waiting for first release in repo")
+    def test_latest_release_gateway(self):
+        latest_release("radixdlt/babylon-gateway")
+
+    @unittest.skip("waiting for public repo")
+    def test_latest_release_nginx(self):
+        latest_release("radixdlt/babylon-nginx")
+
+    @unittest.skip("waiting for public repo")
+    def test_latest_release_nodecli(self):
+        latest_release("radixdlt/babylon-nodecli")
+
+    @unittest.skip("waiting for public repo")
+    def test_latest_release_gateway(self):
+        latest_release("radixdlt/babylon-gateway")
+
+
+if __name__ == '__main__':
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
## Description

Some scenarios are not tested and were not testable. Latest_version was the biggest blocker, as it requires external dependencies and was not mockable. By adding a feature to override the version and allow authentication for requests to come from environment variables. All these problems have been resolved.

Another issue was the long process to test CLI-Command functionality as it required to build the binary and execute it afterwards. New changes would require a new binary. This resulted in a feedback loop of over a minute. Testing from within Python is faster but not fully conclusive or automatic. Which is solved by PROMP_FEEDS. Not all commands can be tested as specific OS versions are required. Future additions aim to enable similar features for Darwin OS as-well.
 
This is a work in progress
