### PR TITLE
DO-1216-Add-option to prompt validator address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install containerd runc
           ./radixnode docker dependencies
+          touch /home/runner/genesis.json
       - name: core-gateway-all-local
         run: |
           ls -a

--- a/docs/command_reference.adoc
+++ b/docs/command_reference.adoc
@@ -65,8 +65,8 @@ optional arguments:
                         prompts using location defined in argument configdir
   -t TRUSTEDNODE, --trustednode TRUSTEDNODE
                         Trusted node on radix network.Example format: 'radix:/
-                        /node_tdx_21_1qfpu6e4xjnjv0anuadnf935kktd2cvycd5evavk9
-                        an56y9pzl3rtk0vzdy5@35.170.44.1'.This is required only
+                        /node_tdx_b_1qdrcdjgzl6s2ymnsssdssxllmmj0j84eagu2m6xtt
+                        tj3nxrunzesyh9fwea@3.109.242.93'.This is required only
                         if you are creating config to run a CORE node and if
                         not provided you will be prompted to enter a value
   -p POSTGRESPASSWORD, --postgrespassword POSTGRESPASSWORD
@@ -268,13 +268,6 @@ optional arguments:
 ==== radixnode system metrics
 [source, bash,subs="+quotes, +attributes" ]
 ----
-usage: radixnode api system metrics [-h]
-
-This command displays prometheus metrics. The response that is printed out is
-in bytes.
-
-optional arguments:
-  -h, --help  show this help message and exit
 ----
 
 ==== radixnode system configuration
@@ -322,13 +315,13 @@ optional arguments:
   -h, --help  show this help message and exit
 ----
 
-==== radixnode system metrics
+==== radixnode system identity
 [source, bash,subs="+quotes, +attributes" ]
 ----
-usage: radixnode api system metrics [-h]
+usage: radixnode api system identity [-h]
 
-This command displays prometheus metrics. The response that is printed out is
-in bytes.
+This command displays information on the status with respect to syncing to
+network.
 
 optional arguments:
   -h, --help  show this help message and exit

--- a/docs/command_reference.adoc
+++ b/docs/command_reference.adoc
@@ -21,8 +21,7 @@ optional arguments:
 usage: radixnode docker config [-h] [-a] [-d CONFIGDIR] [-k KEYSTOREPASSWORD]
                                -m {CORE,GATEWAY,DETAILED}
                                [{CORE,GATEWAY,DETAILED} ...] [-n NETWORKID]
-                               [-nk] [-t TRUSTEDNODE] [-p POSTGRESPASSWORD]
-                               [-xc {true,false}] [-xg {true,false}]
+                               [-nk] [-t TRUSTEDNODE] [-xc {true,false}]
 
 This commands allows node-runners and gateway admins to create a config file,
 which can persist their custom settings. Thus it allows is to decouple the
@@ -69,15 +68,9 @@ optional arguments:
                         tj3nxrunzesyh9fwea@3.109.242.93'.This is required only
                         if you are creating config to run a CORE node and if
                         not provided you will be prompted to enter a value
-  -p POSTGRESPASSWORD, --postgrespassword POSTGRESPASSWORD
-                        Network Gateway uses Postgres as datastore. This is
-                        password for the user `postgres`.
   -xc {true,false}, --disablenginxforcore {true,false}
                         Core Node API's are protected by Basic auth
                         setting.Set this to disable to nginx for core
-  -xg {true,false}, --disablenginxforgateway {true,false}
-                        GateWay API's end points are protected by Basic auth
-                        settings. Set this to disable to nginx for gateway
 ----
 
 ==== radixnode docker install
@@ -423,6 +416,24 @@ optional arguments:
                         Path to config file. Default is
                         '/Users/shambu/monitoring/monitoring_config.yaml'
   -v, --removevolumes   Remove the volumes
+----
+
+==== radixnode key info
+[source, bash,subs="+quotes, +attributes" ]
+----
+usage: radixnode key info [-h] -p PASSWORD -f FILELOCATION
+
+Using CLI, for a key file, you can print out the validator address. This
+feature is in beta.
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+required arguments:
+  -p PASSWORD, --password PASSWORD
+                        Password of the keystore
+  -f FILELOCATION, --filelocation FILELOCATION
+                        Location of keystore on the disk
 ----
 === Other commands supported by CLI
 List of other commands supported by cli are to check the version of CLI being used and optimise-node

--- a/node-runner-cli/commands/dockercommand.py
+++ b/node-runner-cli/commands/dockercommand.py
@@ -64,7 +64,7 @@ def dockercommand(dockercommand_args=[], parent=docker_parser):
                                           " defined in argument configdir", action="store_true"),
     argument("-t", "--trustednode",
              help="Trusted node on radix network."
-                  "Example format: 'radix://node_tdx_21_1qfpu6e4xjnjv0anuadnf935kktd2cvycd5evavk9an56y9pzl3rtk0vzdy5@35.170.44.1'."
+                  "Example format: 'radix://node_tdx_b_1qdrcdjgzl6s2ymnsssdssxllmmj0j84eagu2m6xtttj3nxrunzesyh9fwea@3.109.242.93'."
                   "This is required only if you are creating config to run a CORE node and "
                   "if not provided you will be prompted to enter a value",
              default="",
@@ -117,7 +117,6 @@ def config(args):
         f"\nLocation of the config file: {bcolors.OKBLUE}{config_file}{bcolors.ENDC}")
 
     configuration.common_settings.ask_network_id(networkid)
-    configuration.core_node_settings.ask_validator_address()
     configuration.common_settings.ask_existing_docker_compose_file()
 
     config_to_dump = {"version": "0.2"}
@@ -227,7 +226,7 @@ def install(args):
     if len(compose_file_difference) != 0:
         print(f"""
             {Helpers.section_headline("Differences between existing compose file and new compose file")}
-            Difference between existing config file and new config that you are creating
+             Difference between existing compose file and new compose file that you are creating
             {compose_file_difference}
               """)
         to_update = ""

--- a/node-runner-cli/commands/dockercommand.py
+++ b/node-runner-cli/commands/dockercommand.py
@@ -69,16 +69,9 @@ def dockercommand(dockercommand_args=[], parent=docker_parser):
                   "if not provided you will be prompted to enter a value",
              default="",
              action="store"),
-    argument("-p", "--postgrespassword",
-             help="Network Gateway uses Postgres as datastore. This is password for the user `postgres`.",
-             action="store",
-             default=""),
     argument("-xc", "--disablenginxforcore", help="Core Node API's are protected by Basic auth setting."
                                                   "Set this to disable to nginx for core",
-             action="store", default="", choices=["true", "false"]),
-    argument("-xg", "--disablenginxforgateway", help="GateWay API's end points are protected by Basic auth settings. "
-                                                     "Set this to disable to nginx for gateway",
-             action="store", default="", choices=["true", "false"]),
+             action="store", default="", choices=["true", "false"])
 
 ])
 def config(args):
@@ -93,8 +86,6 @@ def config(args):
     trustednode = args.trustednode if args.trustednode != "" else None
     networkid = args.networkid if args.networkid != "" else None
     keystore_password = args.keystorepassword if args.keystorepassword != "" else None
-    postgrespassword = args.postgrespassword if args.postgrespassword != "" else None
-    nginx_on_gateway = args.disablenginxforgateway if args.disablenginxforgateway != "" else None
     nginx_on_core = args.disablenginxforcore if args.disablenginxforcore != "" else None
     autoapprove = args.autoapprove
     new_keystore = args.newkeystore

--- a/node-runner-cli/commands/dockercommand.py
+++ b/node-runner-cli/commands/dockercommand.py
@@ -96,13 +96,19 @@ def config(args):
               f"Hence cannot be clubbed together with options"
               f"{bcolors.ENDC}")
         sys.exit(1)
-    release = latest_release()
 
+    Helpers.section_headline("CONFIG FILE")
     Path(f"{Helpers.get_default_node_config_dir()}").mkdir(parents=True, exist_ok=True)
     config_file = f"{args.configdir}/config.yaml"
 
+    # Print old config if it exists
+    old_config = Docker.load_all_config(config_file)
+    if len(old_config) != 0:
+        print("\n----There is existing config file and contents are as below----\n")
+        print(f"\n{yaml.dump(old_config)}")
+    release = latest_release()
+
     configuration = DockerConfig(release)
-    Helpers.section_headline("CONFIG FILE")
     print(
         "\nCreating config file using the answers from the questions that would be asked in next steps."
         f"\nLocation of the config file: {bcolors.OKBLUE}{config_file}{bcolors.ENDC}")

--- a/node-runner-cli/commands/key.py
+++ b/node-runner-cli/commands/key.py
@@ -27,7 +27,6 @@ def info(args):
     Using CLI, for a key file, you can print out the validator address. This feature is in beta.
     """
     key = KeyInteraction(keystore_password=str.encode(args.password), keystore_path=args.filelocation)
-    print(f"Validator Address {key.get_validator_address()}")
     print(f"Validator hex public key  {key.get_validator_hex_public_key()}")
 
 # @keycommand([

--- a/node-runner-cli/config/DockerConfig.py
+++ b/node-runner-cli/config/DockerConfig.py
@@ -94,6 +94,7 @@ class CoreDockerSettings(BaseConfig):
 
         self.set_core_release(release)
         self.set_trusted_node(trustednode)
+        self.ask_validator_address()
         self.ask_keydetails(ks_password, new_keystore)
         self.ask_data_directory()
         self.ask_enable_transaction()

--- a/node-runner-cli/generate-cmds-help.sh
+++ b/node-runner-cli/generate-cmds-help.sh
@@ -69,7 +69,7 @@ done
 #  command_api_help_doc "core" "$subcommand" "$filename"
 #done
 
-declare -a systemapicommands=("health" "version" "metrics" "configuration" "peers" "addressbook" "network-sync-status" "metrics")
+declare -a systemapicommands=("health" "version" "metrics" "configuration" "peers" "addressbook" "network-sync-status" "identity")
 for subcommand in "${systemapicommands[@]}"; do
   command_api_help_doc "system" "$subcommand" "$filename"
 done
@@ -89,11 +89,11 @@ done
 #Using CLI, for a key file, you can print out the validator address. This feature is in beta and currently only below commands supported.
 #EOT
 #
-#declare -a keyCommands=("info" )
-#for subcommand in "${keyCommands[@]}"
-#do
-#  command_help_doc "key" "$subcommand" "$filename"
-#done
+declare -a keyCommands=("info" )
+for subcommand in "${keyCommands[@]}"
+do
+  command_help_doc "key" "$subcommand" "$filename"
+done
 
 cat <<EOT >>"$filename"
 === Other commands supported by CLI

--- a/node-runner-cli/setup/Docker.py
+++ b/node-runner-cli/setup/Docker.py
@@ -179,6 +179,7 @@ class Docker(Base):
             to_update = input("\nOkay to update the config file [Y/n]?:")
         if Helpers.check_Yes(to_update) or autoapprove:
             if os.path.exists(config_file):
+                print(f"\n\n Backing up existing config file")
                 Helpers.backup_file(config_file, f"{config_file}_{backup_time}")
             print(f"\n\n Saving to file {config_file} ")
             with open(config_file, 'w') as f:

--- a/node-runner-cli/test-prompts/core-gateway-all-local.yml
+++ b/node-runner-cli/test-prompts/core-gateway-all-local.yml
@@ -1,10 +1,10 @@
 ---
 - select_network: "34"
 - genesis_location: "/home/runner/genesis.json"
-- have_validator_address: "N"
 - first_time_config: Y
 - setup_fullnode: Y
 - input_seednode: "radix://node_tdx_22_1qvsml9pe32rzcrmw6jx204gjeng09adzkqqfz0ewhxwmjsaas99jzrje4u3@34.243.93.185"
+- have_validator_address: "N"
 - have_keystore_file: Y
 - input_path_keystore: "/home/runner/node-config"
 - enter_keystore_name: "node-keystore.ks"

--- a/node-runner-cli/test-prompts/corenode-01.yml
+++ b/node-runner-cli/test-prompts/corenode-01.yml
@@ -1,9 +1,10 @@
 ---
-- select_network: S
-- have_validator_address: "N"
+- select_network: "34"
+- genesis_location: "/home/runner/genesis.json"
 - first_time_config: Y
 - setup_fullnode: Y
 - input_seednode: "radix://node_tdx_21_1qfpu6e4xjnjv0anuadnf935kktd2cvycd5evavk9an56y9pzl3rtk0vzdy5@35.170.44.1"
+- have_validator_address: "N"
 - have_keystore_file: Y
 - input_path_keystore: "/home/runner/node-config"
 - enter_keystore_name: "node-keystore.ks"

--- a/node-runner-cli/test-prompts/corenode-02.yml
+++ b/node-runner-cli/test-prompts/corenode-02.yml
@@ -1,10 +1,11 @@
 ---
-- select_network: S
-- have_validator_address: "N"
+- select_network: "34"
+- genesis_location: "/home/runner/genesis.json"
 - first_time_config: N
 - have_existing_compose: "/home/runner/docker-compose.yml"
 - setup_fullnode: Y
 - input_seednode: "radix://node_tdx_21_1qfpu6e4xjnjv0anuadnf935kktd2cvycd5evavk9an56y9pzl3rtk0vzdy5@35.170.44.1"
+- have_validator_address: "N"
 - have_keystore_file: N
 - input_path_keystore: "/home/runner/node-config"
 - enter_keystore_name: "node-keystore.ks"

--- a/node-runner-cli/utils/Network.py
+++ b/node-runner-cli/utils/Network.py
@@ -37,7 +37,7 @@ class Network:
             genesis_json_location = Prompts.check_default(Helpers.input_guestion(
                 f"Enter absolute path to genesis json. Default location is {bcolors.OKBLUE}{config_dir}{bcolors.ENDC}:",
                 QuestionKeys.genesis_location), config_dir)
-
+            Helpers.is_valid_file(genesis_json_location)
 
         elif network_id == 11:
             genesis_json_location = f"{Helpers.get_default_node_config_dir()}/nebunet-genesis.json"

--- a/node-runner-cli/utils/Network.py
+++ b/node-runner-cli/utils/Network.py
@@ -37,7 +37,7 @@ class Network:
             genesis_json_location = Prompts.check_default(Helpers.input_guestion(
                 f"Enter absolute path to genesis json. Default location is {bcolors.OKBLUE}{config_dir}{bcolors.ENDC}:",
                 QuestionKeys.genesis_location), config_dir)
-            Helpers.is_valid_file(genesis_json_location)
+
 
         elif network_id == 11:
             genesis_json_location = f"{Helpers.get_default_node_config_dir()}/nebunet-genesis.json"

--- a/node-runner-cli/utils/Network.py
+++ b/node-runner-cli/utils/Network.py
@@ -11,6 +11,7 @@ class Network:
     @staticmethod
     def get_network_id() -> int:
         # Network id
+        Helpers.section_headline(f"Network connection")
         network_prompt = Helpers.input_guestion(
             "Select the network you want to connect [S]Stokenet or [M]Mainnet or network_id:",
             QuestionKeys.select_network)

--- a/node-runner-cli/utils/Prompts.py
+++ b/node-runner-cli/utils/Prompts.py
@@ -333,11 +333,15 @@ class Prompts:
     @classmethod
     def ask_validator_address(cls) -> str:
         validator_address = ""
-        answer = Helpers.input_guestion(f"Do you have a validator address? (Y/n)"
-                                        "\nIf you are running this command for the first time, you will not have one."
-                                        "\nAfter your node is up and running, you can receive the validator address by"
-                                        " sending a request to /system/identity"
-                                        " or by executing 'radixnode api system identity'."
+        print("If you want to run this node as validator,"
+              "you would need to store validator address in the config"
+              "\nAfter your node is up and running, you can get you node public key by"
+              " sending a request to /system/identity"
+              " or by executing 'radixnode api system identity'. "
+              "Refer this link for more details"
+              "https://docs-babylon.radixdlt.com/main/node-and-gateway/register-as-validator.html#_gather_your_node_public_key"
+              "")
+        answer = Helpers.input_guestion(f"\n\n Do you have a validator address? (Y/n)"
                                         , QuestionKeys.have_validator_address)
         if Helpers.check_Yes(Prompts.check_default(answer, "N")):
             validator_address = Helpers.input_guestion(f"Enter your validator address:",

--- a/node-runner-cli/utils/Prompts.py
+++ b/node-runner-cli/utils/Prompts.py
@@ -198,7 +198,7 @@ class Prompts:
 
     @staticmethod
     def ask_trusted_node() -> str:
-
+        Helpers.section_headline("Trusted node settings")
         value = Helpers.input_guestion("Fullnode requires another node to connect to network. "
                                        "\nTo connect to MAINNET or STOKENET details on these node can be found here "
                                        "- https://docs.radixdlt.com/main/node-and-gateway/seed-nodes.html"
@@ -332,17 +332,18 @@ class Prompts:
 
     @classmethod
     def ask_validator_address(cls) -> str:
-        validator_address = ""
-        print("If you want to run this node as validator,"
+        Helpers.section_headline("Validator Address")
+        print("\n\nIf you want to run this node as validator,"
               "you would need to store validator address in the config"
               "\nAfter your node is up and running, you can get you node public key by"
               " sending a request to /system/identity"
               " or by executing 'radixnode api system identity'. "
               "Refer this link for more details"
-              "https://docs-babylon.radixdlt.com/main/node-and-gateway/register-as-validator.html#_gather_your_node_public_key"
+              "\n https://docs-babylon.radixdlt.com/main/node-and-gateway/register-as-validator.html#_gather_your_node_public_key"
               "")
-        answer = Helpers.input_guestion(f"\n\n Do you have a validator address? (Y/n)"
+        answer = Helpers.input_guestion(f"\n\n Do you have a validator address? (Y/n): "
                                         , QuestionKeys.have_validator_address)
+        validator_address = ""
         if Helpers.check_Yes(Prompts.check_default(answer, "N")):
             validator_address = Helpers.input_guestion(f"Enter your validator address:",
                                                        QuestionKeys.validator_address)

--- a/node-runner-cli/utils/Prompts.py
+++ b/node-runner-cli/utils/Prompts.py
@@ -204,10 +204,10 @@ class Prompts:
                                        "- https://docs.radixdlt.com/main/node-and-gateway/seed-nodes.html"
                                        "\nType in the node you want to connect to in format radix://<node-peer-2-peer-address>@<ip>"
                                        "\n OR press Enter to accept default "
-                                       "radix://node_tdx_21_1qfpu6e4xjnjv0anuadnf935kktd2cvycd5evavk9an56y9pzl3rtk0vzdy5@35.170.44.1:",
+                                       "radix://node_tdx_b_1qdrcdjgzl6s2ymnsssdssxllmmj0j84eagu2m6xtttj3nxrunzesyh9fwea@3.109.242.93:",
                                        QuestionKeys.input_seednode)
         trustednode = Prompts.check_default(value,
-                                            "radix://node_tdx_21_1qfpu6e4xjnjv0anuadnf935kktd2cvycd5evavk9an56y9pzl3rtk0vzdy5@35.170.44.1")
+                                            "radix://node_tdx_b_1qdrcdjgzl6s2ymnsssdssxllmmj0j84eagu2m6xtttj3nxrunzesyh9fwea@3.109.242.93")
         Helpers.parse_trustednode(trustednode)
         return trustednode
 
@@ -336,8 +336,8 @@ class Prompts:
         answer = Helpers.input_guestion(f"Do you have a validator address? (Y/n)"
                                         "\nIf you are running this command for the first time, you will not have one."
                                         "\nAfter your node is up and running, you can receive the validator address by"
-                                        "sending a request to /system/identity"
-                                        "or by executing 'radixnode api system identity'."
+                                        " sending a request to /system/identity"
+                                        " or by executing 'radixnode api system identity'."
                                         , QuestionKeys.have_validator_address)
         if Helpers.check_Yes(Prompts.check_default(answer, "N")):
             validator_address = Helpers.input_guestion(f"Enter your validator address:",

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -330,16 +330,9 @@ class Helpers:
 
     @staticmethod
     def is_valid_file(file: str):
-        if not os.access(file, os.W_OK):
-            try:
-                open(file, 'w').close()
-                os.unlink(file)
-            except OSError:
-                print(f"OS error occurred trying to open {file}")
-                sys.exit(1)
-            except Exception as err:
-                print(f"Unexpected error opening {file} is", repr(err))
-                sys.exit(1)
+        if not os.path.exists(file):
+            print(f" `{file}` does not exist ")
+            sys.exit(1)
 
 
 class bcolors:

--- a/node-runner-cli/version/__init__.py
+++ b/node-runner-cli/version/__init__.py
@@ -1,2 +1,2 @@
-__version__= "2.0.0-rc-60-gbef1b49"
+__version__= "2.0.0-rc-62-gaa90c61"
 __base_version__= "2.0.0-rc"

--- a/node-runner-cli/version/__init__.py
+++ b/node-runner-cli/version/__init__.py
@@ -1,2 +1,2 @@
-__version__= "2.0.0-rc-59-g9c9b141"
+__version__= "2.0.0-rc-60-gbef1b49"
 __base_version__= "2.0.0-rc"

--- a/node-runner-cli/version/__init__.py
+++ b/node-runner-cli/version/__init__.py
@@ -1,2 +1,2 @@
-__version__= "2.0.0-rc-58-ga6744a2"
+__version__= "2.0.0-rc-59-g9c9b141"
 __base_version__= "2.0.0-rc"

--- a/node-runner-cli/version/__init__.py
+++ b/node-runner-cli/version/__init__.py
@@ -1,2 +1,2 @@
-__version__= "2.0.0-rc-56-gbd71bad"
+__version__= "2.0.0-rc-58-ga6744a2"
 __base_version__= "2.0.0-rc"

--- a/node-runner-cli/version/__init__.py
+++ b/node-runner-cli/version/__init__.py
@@ -1,2 +1,2 @@
-__version__= "2.0.0-rc-38-gfcc59f4"
+__version__= "2.0.0-rc-56-gbd71bad"
 __base_version__= "2.0.0-rc"


### PR DESCRIPTION
- Add option to prompt for validator address
- Update default trustnode to point to babylon betanet 
- Bring back key info command that can print validator address
- Print existing config file if present as users need to renter the values for validator setup
- Fix the file location bug
