### PR TITLE
DO-1227/fix-monitoring-template-reference

### DIFF
--- a/node-runner-cli/commands/monitoring.py
+++ b/node-runner-cli/commands/monitoring.py
@@ -140,8 +140,8 @@ def install(args):
     monitoring_config_dir = all_config["common_config"]["config_dir"]
     Monitoring.template_prometheus_yml(all_config, monitoring_config_dir)
     Monitoring.template_datasource(monitoring_config_dir)
-    Monitoring.template_dashboards(["dashboard.yml", "sample-node-dashboard.json", "network-gateway-dashboard.json"],
-                                   monitoring_config_dir)
+    Monitoring.template_dashboards(["dashboard.yml", "babylon-node-dashboard.json", "babylon-jvm-dashboard.json",
+                                    "network-gateway-dashboard.json"], monitoring_config_dir)
 
     Monitoring.template_monitoring_containers(monitoring_config_dir)
     Monitoring.setup_external_volumes()

--- a/node-runner-cli/tests/test_monitoring.py
+++ b/node-runner-cli/tests/test_monitoring.py
@@ -9,6 +9,9 @@ class MonitoringTests(unittest.TestCase):
         Monitoring.template_dashboards(["dashboard.yml", "babylon-node-dashboard.json", "babylon-jvm-dashboard.json",
                                         "network-gateway-dashboard.json"], "/tmp")
         self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/network-gateway-dashboard.json"))
+        self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/dashboard.yml"))
+        self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/babylon-jvm-dashboard.json"))
+        self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/network-gateway-dashboard.json"))
 
 
 if __name__ == '__main__':

--- a/node-runner-cli/tests/test_monitoring.py
+++ b/node-runner-cli/tests/test_monitoring.py
@@ -1,5 +1,8 @@
 import os.path
 import unittest
+from io import StringIO
+from unittest import mock
+from jinja2.exceptions import TemplateNotFound
 from monitoring import Monitoring
 
 
@@ -12,6 +15,13 @@ class MonitoringTests(unittest.TestCase):
         self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/dashboard.yml"))
         self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/babylon-jvm-dashboard.json"))
         self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/network-gateway-dashboard.json"))
+
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_template_failure(self, mock_stdout):
+        with self.assertRaises(TemplateNotFound) as cm:
+            Monitoring.template_dashboards(["this-template-does-not-exist"], "/tmp")
+            self.assertEqual(mock_stdout.getvalue(), "jinja2.exceptions.TemplateNotFound: this-template-does-not-exist.j2")
+            self.assertEqual(cm.exception.code, 1)
 
 
 if __name__ == '__main__':

--- a/node-runner-cli/tests/test_monitoring.py
+++ b/node-runner-cli/tests/test_monitoring.py
@@ -2,12 +2,14 @@ import os.path
 import unittest
 from monitoring import Monitoring
 
-class MyTestCase(unittest.TestCase):
+
+class MonitoringTests(unittest.TestCase):
 
     def test_template(self):
         Monitoring.template_dashboards(["dashboard.yml", "babylon-node-dashboard.json", "babylon-jvm-dashboard.json",
                                         "network-gateway-dashboard.json"], "/tmp")
         self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/network-gateway-dashboard.json"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/node-runner-cli/tests/test_monitoring.py
+++ b/node-runner-cli/tests/test_monitoring.py
@@ -1,0 +1,13 @@
+import os.path
+import unittest
+from monitoring import Monitoring
+
+class MyTestCase(unittest.TestCase):
+
+    def test_template(self):
+        Monitoring.template_dashboards(["dashboard.yml", "babylon-node-dashboard.json", "babylon-jvm-dashboard.json",
+                                        "network-gateway-dashboard.json"], "/tmp")
+        self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/network-gateway-dashboard.json"))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/node-runner-cli/tests/test_network.py
+++ b/node-runner-cli/tests/test_network.py
@@ -42,9 +42,12 @@ class NetworkUtilsUnitTests(unittest.TestCase):
         genesis_location = Network.path_to_genesis_json(2)
         self.assertEqual(genesis_location, None)
 
-        with mock.patch('builtins.input', return_value='/tmp/path'):
-            genesis_location = Network.path_to_genesis_json(3)
-        self.assertEqual(genesis_location, "/tmp/path")
+        with self.assertRaises(SystemExit) as cm:
+            with mock.patch('builtins.input', return_value='/tmp/path'):
+                genesis_location = Network.path_to_genesis_json(3)
+            self.assertEqual(genesis_location, "/tmp/path")
+            self.assertEqual(mock_stdout.getvalue(), f" `{genesis_location}` does not exist ")
+            self.assertEqual(cm.exception.code, 1)
 
         with self.assertRaises(SystemExit) as cm:
             with mock.patch('builtins.input', return_value='/tm\\$&(*!@£^(p(^)th'):
@@ -59,10 +62,14 @@ class NetworkUtilsUnitTests(unittest.TestCase):
         self.assertIn("gilganet", genesis_location)
 
     def test_hammunet_genesis_files(self):
-        settings = CommonDockerSettings({})
-        with mock.patch('builtins.input', side_effect=['34', '/tmp/hammunet_genesis.json']):
-            settings.ask_network_id(None)
-        self.assertIn("hammunet_genesis.json", settings.genesis_json_location)
+
+        with self.assertRaises(SystemExit) as cm:
+            settings = CommonDockerSettings({})
+            with mock.patch('builtins.input', side_effect=['34', '/tmp/hammunet_genesis.json']):
+                settings.ask_network_id(None)
+            self.assertIn("hammunet_genesis.json", settings.genesis_json_location)
+            self.assertEqual(mock_stdout.getvalue(), f" `{settings.genesis_json_location}` does not exist ")
+            self.assertEqual(cm.exception.code, 1)
 
 
 def suite():


### PR DESCRIPTION
## Fix monitoring templating

This was a bug caused by oversight. I missed that the dashboard template files were referenced here. Updated the reference to include the new dashboard templates and removed the outdated ones. 

Added simple tests about it and fixed the network tests that broke due to the new valid file constraint.