### PR TITLE
tech-debt/Unit Tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,11 @@ jobs:
           make local
       - name: Execute Unit Tests
         run: |
+          cd node-runner-cli
           make test
       - name: Build the binary for ubuntu
         run: |
+          cd node-runner-cli
           make output-ubuntu-focal
       - name: "Upload generated cli file"
         uses: actions/upload-artifact@v2.2.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,13 @@ jobs:
         uses: actions/setup-python@v2.2.1
         with:
           python-version: 3.7.6
-      - name: Execute Unit Tests
+      - name: Build application local
         run: |
           cd node-runner-cli
+          make install
+          make local
+      - name: Execute Unit Tests
+        run: |
           make test
       - name: Build the binary for ubuntu
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,12 @@ jobs:
         uses: actions/setup-python@v2.2.1
         with:
           python-version: 3.7.6
-      - name: Build the binary for ubuntu
+      - name: Execute Unit Tests
         run: |
           cd node-runner-cli
+          make test
+      - name: Build the binary for ubuntu
+        run: |
           make output-ubuntu-focal
       - name: "Upload generated cli file"
         uses: actions/upload-artifact@v2.2.3

--- a/node-runner-cli/tests/test_monitoring.py
+++ b/node-runner-cli/tests/test_monitoring.py
@@ -8,7 +8,8 @@ from monitoring import Monitoring
 
 class MonitoringTests(unittest.TestCase):
 
-    def test_template(self):
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_template(self, mock_stdout):
         Monitoring.template_dashboards(["dashboard.yml", "babylon-node-dashboard.json", "babylon-jvm-dashboard.json",
                                         "network-gateway-dashboard.json"], "/tmp")
         self.assertTrue(os.path.exists("/tmp/grafana/provisioning/dashboards/network-gateway-dashboard.json"))

--- a/node-runner-cli/tests/test_network.py
+++ b/node-runner-cli/tests/test_network.py
@@ -55,14 +55,15 @@ class NetworkUtilsUnitTests(unittest.TestCase):
             self.assertEqual(mock_stdout.getvalue(), "OS error occurred trying to open /tm\\$&(*!@£^(p(^)th")
             self.assertEqual(cm.exception.code, 1)
 
-    def test_default_genesis_files(self):
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_default_genesis_files(self, mock_stdout):
         genesis_location = Network.path_to_genesis_json(11)
         self.assertIn("nebunet", genesis_location)
         genesis_location = Network.path_to_genesis_json(32)
         self.assertIn("gilganet", genesis_location)
 
-    def test_hammunet_genesis_files(self):
-
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_hammunet_genesis_files(self, mock_stdout):
         with self.assertRaises(SystemExit) as cm:
             settings = CommonDockerSettings({})
             with mock.patch('builtins.input', side_effect=['34', '/tmp/hammunet_genesis.json']):

--- a/node-runner-cli/tests/test_validator.py
+++ b/node-runner-cli/tests/test_validator.py
@@ -14,12 +14,15 @@ from utils.Prompts import Prompts
 
 class ValidatorUnitTests(unittest.TestCase):
 
-    def test_can_set_validator_address(self):
+
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_can_set_validator_address(self, mock_stdout):
         core_settings = CoreDockerSettings({})
         core_settings.set_validator_address("validator_mock")
         self.assertEqual(core_settings.validator_address, "validator_mock")
 
-    def test_prompt_validator_address(self):
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_prompt_validator_address(self, mock_stdout):
         with mock.patch('builtins.input', side_effect=['Y', 'validator_address_5']):
             validator_address = Prompts.ask_validator_address()
             self.assertEqual(validator_address, "validator_address_5")
@@ -27,7 +30,8 @@ class ValidatorUnitTests(unittest.TestCase):
             validator_address = Prompts.ask_validator_address()
             self.assertEqual(validator_address, "")
 
-    def test_validator_address_get_templated_into_docker_compose(self):
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_validator_address_get_templated_into_docker_compose(self, mock_stdout):
         validator_address_fixture = "validator_mock"
         settings = {'core_node': {'validator_address': validator_address_fixture,
                                   'repo': 'some',


### PR DESCRIPTION
# Unit Tests in CI

This adds the unit tests and building of the application to the CI step "Package cli for Ubuntu". This ensures only functional artifacts are created.

Some tests have been muted as to not clutter the logs with passing tests.