### PR TITLE
prettify output format for all api commands

### DIFF
--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -97,9 +97,9 @@ class Helpers:
         s = requests.Session()
         resp = s.send(prepared, verify=False)
         if Helpers.is_json(resp.content):
-            response_content = json.dumps(resp.json())
+            response_content = json.dumps(resp.json(), indent=2)
         else:
-            response_content = resp.content
+            response_content = resp.content.decode("utf-8")
 
         if print_response:
             print(response_content)


### PR DESCRIPTION
**Changes:**
- Decode plain text html messages from byte code
- add indention (and therefore force formatting) to json responses

**Known issues:**
- html code prints status code of http request for some reason


**Example output (cut short for readability):**
`
radixdlt@ip-172-31-26-71:~$ /tmp/radixnode api metrics
# HELP rn_ledger_last_update_epoch_second Last timestamp at which the ledger was updated.
# TYPE rn_ledger_last_update_epoch_second gauge
rn_ledger_last_update_epoch_second 1679576527.9903533
...
# HELP Special metric used to convey information about the current node using labels. Value will always be 0.
# TYPE nodeinfo counter
nodeinfo{health="SYNCING",} 0.0


<Response [200]>
radixdlt@ip-172-31-26-71:~$ /tmp/radixnode api system identity
{
  "public_key_hex": "03cbb2cbbb0289968981dc2465fb04a475df3a62ac251aa2c4e7bdab0b78ed551c",
  "node_address": "node_tdx_b_1q09m9jamq2yedzvpmsjxt7cy536a7wnz4sj34gkyu776kzmca423c9nw9mq",
  "node_uri": "radix://node_tdx_b_1q09m9jamq2yedzvpmsjxt7cy536a7wnz4sj34gkyu776kzmca423c9nw9mq@35.178.142.54:30000",
  "node_name": "no...23c9nw9mq",
  "node_id": "NodeId[03cbb2cbbb0289968981dc2465fb04a475df3a62ac251aa2c4e7bdab0b78ed551c]",
  "validator_name": "03cbb2cbbb",
  "consensus_status": "NOT_CONFIGURED_AS_VALIDATOR"
}
radixdlt@ip-172-31-26-71:~$ /tmp/radixnode api system identity | jq
{
  "public_key_hex": "03cbb2cbbb0289968981dc2465fb04a475df3a62ac251aa2c4e7bdab0b78ed551c",
  "node_address": "node_tdx_b_1q09m9jamq2yedzvpmsjxt7cy536a7wnz4sj34gkyu776kzmca423c9nw9mq",
  "node_uri": "radix://node_tdx_b_1q09m9jamq2yedzvpmsjxt7cy536a7wnz4sj34gkyu776kzmca423c9nw9mq@35.178.142.54:30000",
  "node_name": "no...23c9nw9mq",
  "node_id": "NodeId[03cbb2cbbb0289968981dc2465fb04a475df3a62ac251aa2c4e7bdab0b78ed551c]",
  "validator_name": "03cbb2cbbb",
  "consensus_status": "NOT_CONFIGURED_AS_VALIDATOR"
}
`