### PR TITLE
chore: update memory defaults

### DIFF
--- a/node-runner-cli/commands/dockercommand.py
+++ b/node-runner-cli/commands/dockercommand.py
@@ -141,7 +141,6 @@ def install(args):
 
     ########## Update existing Config
     docker_config: DockerConfig = DockerSetup.load_settings(argument_object.config_file)
-    docker_config = DockerSetup.verify_memory_settings_migration(docker_config)
     docker_config_updated_versions = DockerSetup.update_versions(docker_config,
                                                                  argument_object.autoapprove) if argument_object.update else docker_config
 

--- a/node-runner-cli/commands/systemdcommand.py
+++ b/node-runner-cli/commands/systemdcommand.py
@@ -126,7 +126,6 @@ def config(args):
 def install(args):
     """This sets up the systemd service for the core node."""
     settings: SystemDConfig = SystemDSetup.load_settings(args.configfile)
-    settings = SystemDSetup.verify_memory_settings_migration(settings)
     SystemDSetup.install_systemd_service(settings, args)
 
 

--- a/node-runner-cli/config/CoreDockerConfig.py
+++ b/node-runner-cli/config/CoreDockerConfig.py
@@ -20,9 +20,9 @@ class CoreDockerConfig(BaseConfig):
         self.repo: str = os.getenv(CORE_DOCKER_REPO_OVERRIDE, "radixdlt/babylon-node")
         self.data_directory: str = f"{Helpers.get_home_dir()}/babylon-ledger"
         self.trusted_node: str = ""
-        self.memory_limit: str = "12000m"
+        self.memory_limit: str = "14000m"
         self.validator_address: str = ""
-        self.java_opts: str = "--enable-preview -server -Xms8g -Xmx8g  " \
+        self.java_opts: str = "--enable-preview -server -Xms12g -Xmx12g  " \
                               "-XX:MaxDirectMemorySize=2048m " \
                               "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops " \
                               "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts " \

--- a/node-runner-cli/config/CoreSystemDConfig.py
+++ b/node-runner-cli/config/CoreSystemDConfig.py
@@ -24,7 +24,7 @@ class CoreSystemdConfig(BaseConfig):
         self.node_dir: str = '/etc/radixdlt/node'
         self.node_secrets_dir: str = '/etc/radixdlt/node/secrets'
         self.validator_address: str = ""
-        self.java_opts: str = "--enable-preview -server -Xms8g -Xmx8g  " \
+        self.java_opts: str = "--enable-preview -server -Xms12g -Xmx12g  " \
                               "-XX:MaxDirectMemorySize=2048m " \
                               "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops " \
                               "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts " \

--- a/node-runner-cli/setup/DockerSetup.py
+++ b/node-runner-cli/setup/DockerSetup.py
@@ -351,10 +351,10 @@ class DockerSetup(BaseSetup):
         if docker_config != None:
             if docker_config.migration != None:
                 if docker_config.migration.use_olympia:
-                    if docker_config.core_node.memory_limit == "12000m" or docker_config.core_node.memory_limit == None:
+                    if docker_config.core_node.memory_limit == "14000m" or docker_config.core_node.memory_limit == None:
                         if Prompts.ask_temporary_mem_limits_update():
                             docker_config.core_node.memory_limit = "14000m"
-                    if "-Xms8g -Xmx8g" in docker_config.core_node.java_opts:
+                    if "-Xms12g -Xmx12g" in docker_config.core_node.java_opts:
                         if Prompts.ask_temporary_java_opts_update():
                             docker_config.core_node.java_opts = "--enable-preview -server -Xms12g -Xmx12g  " \
                                                                 "-XX:MaxDirectMemorySize=2048m " \

--- a/node-runner-cli/setup/MigrationSetup.py
+++ b/node-runner-cli/setup/MigrationSetup.py
@@ -8,13 +8,14 @@ class MigrationSetup:
         new_config = current_config
         new_config.migration.use_olympia = True
 
-        new_config.core_node.memory_limit: str = "14000m"
-        new_config.core_node.java_opts = "--enable-preview -server -Xms12g -Xmx12g  " \
-                                         "-XX:MaxDirectMemorySize=2048m " \
-                                         "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops " \
-                                         "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts " \
-                                         "-Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom " \
-                                         "-DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
+        # Moved to default values
+        # new_config.core_node.memory_limit: str = "14000m"
+        # new_config.core_node.java_opts = "--enable-preview -server -Xms12g -Xmx12g  " \
+        #                                  "-XX:MaxDirectMemorySize=2048m " \
+        #                                  "-XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops " \
+        #                                  "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts " \
+        #                                  "-Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom " \
+        #                                  "-DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
         if olympia_node_url is None:
             olympia_node_url = Prompts.ask_olympia_node_url()
         new_config.migration.olympia_node_url = olympia_node_url

--- a/node-runner-cli/setup/SystemDSetup.py
+++ b/node-runner-cli/setup/SystemDSetup.py
@@ -444,7 +444,7 @@ class SystemDSetup(BaseSetup):
         if settings != None:
             if settings.migration != None:
                 if settings.migration.use_olympia:
-                    if "-Xms8g -Xmx8g" in settings.core_node.java_opts:
+                    if "-Xms12g -Xmx12g" in settings.core_node.java_opts:
                         if Prompts.ask_temporary_java_opts_update():
                             settings.core_node.java_opts = "--enable-preview -server -Xms12g -Xmx12g  " \
                                                            "-XX:MaxDirectMemorySize=2048m " \

--- a/node-runner-cli/templates/radix-fullnode-compose.yml.j2
+++ b/node-runner-cli/templates/radix-fullnode-compose.yml.j2
@@ -5,7 +5,7 @@ services:
     cap_add:
     - NET_ADMIN
     environment:
-      JAVA_OPTS: {{core_node.java_opts or '--enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector'}}
+      JAVA_OPTS: {{core_node.java_opts or '--enable-preview -server -Xms12g -Xmx12g  -XX:MaxDirectMemorySize=2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector'}}
       RADIXDLT_API_PORT: 3333
       RADIXDLT_LOG_LEVEL: {{core_node.log_level or 'info'}}
       RADIXDLT_NETWORK_ID: {{common_config.network_id}}
@@ -30,7 +30,7 @@ services:
       {% endif %}
     image: {{core_node.repo}}:{{core_node.core_release}}
     init: true
-    mem_limit: {{core_node.memory_limit or '12000m'}}
+    mem_limit: {{core_node.memory_limit or '14000m'}}
     restart: unless-stopped
     {% if common_config.nginx_settings is not defined or (common_config.nginx_settings.protect_core | lower | trim) == "false" %}
     ports:

--- a/node-runner-cli/tests/e2e/configs/expected/core_config.yaml
+++ b/node-runner-cli/tests/e2e/configs/expected/core_config.yaml
@@ -14,7 +14,7 @@ core_node:
   composefileurl: ''
   core_release: rcnet-v3.1-r1
   data_directory: /Users/santi/babylon-ledger
-  java_opts: --enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m
+  java_opts: --enable-preview -server -Xms12g -Xmx12g  -XX:MaxDirectMemorySize=2048m
     -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
     -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
   keydetails:

--- a/node-runner-cli/tests/e2e/configs/expected/gateway_config.yml
+++ b/node-runner-cli/tests/e2e/configs/expected/gateway_config.yml
@@ -14,7 +14,7 @@ core_node:
   composefileurl: ''
   core_release: rcnet-v3.1-r1
   data_directory: /Users/santi/babylon-ledger
-  java_opts: --enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m
+  java_opts: --enable-preview -server -Xms12g -Xmx12g  -XX:MaxDirectMemorySize=2048m
     -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
     -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
   keydetails:

--- a/node-runner-cli/tests/fixtures/config-gateway-docker.yaml
+++ b/node-runner-cli/tests/fixtures/config-gateway-docker.yaml
@@ -14,7 +14,7 @@ core_node:
   composefileurl: ''
   core_release: rcnet-v3.1-r1
   data_directory: /home/radixdlt/babylon-ledger
-  java_opts: --enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m
+  java_opts: --enable-preview -server -Xms12g -Xmx12g  -XX:MaxDirectMemorySize=2048m
     -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
     -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
   keydetails:

--- a/node-runner-cli/tests/fixtures/docker-compose.yaml
+++ b/node-runner-cli/tests/fixtures/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     cap_add:
     - NET_ADMIN
     environment:
-      JAVA_OPTS: --enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m
+      JAVA_OPTS: --enable-preview -server -Xms12g -Xmx12g  -XX:MaxDirectMemorySize=2048m
         -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
         -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
       RADIXDLT_API_PORT: 3333
@@ -19,7 +19,7 @@ services:
       RADIX_NODE_KEYSTORE_PASSWORD: radix
     image: docker.io/radixdlt/private-babylon-node:release-birch-ffbc9b5273
     init: true
-    mem_limit: 12000m
+    mem_limit: 14000m
     restart: unless-stopped
     ulimits:
       memlock: -1

--- a/node-runner-cli/tests/fixtures/docker-config.yaml
+++ b/node-runner-cli/tests/fixtures/docker-config.yaml
@@ -15,7 +15,7 @@ common_config:
 core_node:
   core_release: release-birch-ffbc9b5273
   data_directory: /home/radixdlt/data
-  java_opts: --enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m
+  java_opts: --enable-preview -server -Xms12g -Xmx12g  -XX:MaxDirectMemorySize=2048m
     -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
     -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
   keydetails:

--- a/node-runner-cli/tests/unit/test_diff_human_readable.py
+++ b/node-runner-cli/tests/unit/test_diff_human_readable.py
@@ -54,7 +54,7 @@
 #                           '          "core_library_url": "",\n'
 #                           '          "core_release": "",\n'
 #                           '          "data_directory": "/Users/kim.fehrs/babylon-ledger",\n'
-#                           '          "java_opts": "--enable-preview -server -Xms8g -Xmx8g  '
+#                           '          "java_opts": "--enable-preview -server -Xms12g -Xmx12g  '
 #                           '-XX:MaxDirectMemorySize=2048m -XX:+HeapDumpOnOutOfMemoryError '
 #                           '-XX:+UseCompressedOops '
 #                           '-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts '

--- a/node-runner-cli/tests/unit/test_docker.py
+++ b/node-runner-cli/tests/unit/test_docker.py
@@ -101,14 +101,14 @@ class DockerUnitTests(unittest.TestCase):
         self.assertEqual(None, docker_compose_yaml["services"]["core"][
             "environment"].get("RADIXDLT_GENESIS_DATA_FILE"))
 
-    def test_docker_java_opts_normal_not_on_migration(self):
+    def test_docker_java_opts_not_migration_are_same_as_for_migration(self):
         self.maxDiff = None
         settings = DockerConfig({})
         settings.core_node.core_release = "test"
         settings.common_config.nginx_settings.release = "test"
         docker_compose_yaml = DockerSetup.render_docker_compose(settings)
         java_opts = docker_compose_yaml["services"]["core"]["environment"]["JAVA_OPTS"]
-        self.assertRegex(java_opts, '.*-Xms8g -Xmx8g.*')
+        self.assertRegex(java_opts, '.*-Xms12g -Xmx12g.*')
 
     def test_docker_java_opts_increased_on_migration(self):
         self.maxDiff = None

--- a/node-runner-cli/tests/unit/test_systemd.py
+++ b/node-runner-cli/tests/unit/test_systemd.py
@@ -255,7 +255,7 @@ WantedBy=multi-user.target"""
         settings.core_node.keydetails.keystore_password = "nowthatyouknowmysecretiwillfollowyouuntilyouforgetit"
         render_template = Renderer().load_file_based_template("systemd-environment.j2").render(
             settings.to_dict()).rendered
-        fixture = f"""JAVA_OPTS="--enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
+        fixture = f"""JAVA_OPTS="--enable-preview -server -Xms12g -Xmx12g  -XX:MaxDirectMemorySize=2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
 RADIX_NODE_KEYSTORE_PASSWORD=nowthatyouknowmysecretiwillfollowyouuntilyouforgetit"""
         self.maxDiff = None
         self.assertEqual(fixture, render_template)
@@ -303,7 +303,7 @@ RADIX_NODE_KEYSTORE_PASSWORD=nowthatyouknowmysecretiwillfollowyouuntilyouforgeti
         settings.core_node.core_release = "test"
         settings.common_config.nginx_settings.release = "test"
         environment_yaml = settings.create_environment_yaml()
-        self.assertTrue("-Xms8g -Xmx8g" in environment_yaml)
+        self.assertTrue("-Xms12g -Xmx12g" in environment_yaml)
 
     def test_systemd_java_opts_increased_on_migration(self):
         self.maxDiff = None


### PR DESCRIPTION
Make memory configruation for migration the default for every run.
Remove prompt to increase memory settings based on migration status.