### PR TITLE
ci: fix labeler github action [DO-2126]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,7 @@
 ansible:
-  - node-runner-cli/*
+  - changed-files:
+    - any-glob-to-any-file: 'node-runner-cli/*'
 
 ci:
-  - .github/*
+  - changed-files:
+    - any-glob-to-any-file: '.github/*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request
+  - pull_request_target
 
 permissions:
   checks: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,11 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  - pull_request
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
 
 jobs:
   label_pr:


### PR DESCRIPTION
Fix labeler github action to use new config format.

It's fine that it's failing in PR, here is explanation:
```
When submitting an initial pull request to a repository using the pull_request_target event, the labeler workflow will not run on that pull request because the pull_request_target execution runs off the base branch instead of the pull request's branch. Unfortunately this means the introduction of the labeler can not be verified during that pull request and it needs to be committed blindly.
```