### PR TITLE
Use -dsaparam flag in openssl cert generation

### DIFF
--- a/node-runner-cli/setup/SystemDSetup.py
+++ b/node-runner-cli/setup/SystemDSetup.py
@@ -275,13 +275,13 @@ class SystemDSetup(BaseSetup):
                 answer = input("Do you want to regenerate y/n :")
                 if Helpers.check_Yes(answer):
                     run_shell_command(
-                        f"sudo openssl dhparam -out {secrets_dir}/dhparam.pem  4096",
+                        f"sudo openssl dhparam -dsaparam -out {secrets_dir}/dhparam.pem 4096",
                         shell=True,
                     )
         else:
             print("Generating a dhparam.pem file")
             run_shell_command(
-                f"sudo openssl dhparam -out {secrets_dir}/dhparam.pem  4096", shell=True
+                f"sudo openssl dhparam -dsaparam -out {secrets_dir}/dhparam.pem 4096", shell=True
             )
 
     @staticmethod


### PR DESCRIPTION
This speeds up key generation.

From the manual:

```
-dsaparam
If this option is used, DSA rather than DH parameters are read or created; they are converted to DH format. Otherwise, "strong" primes (such that (p-1)/2 is also prime) will be used for DH parameter generation.

DH parameter generation with the -dsaparam option is much faster, and the recommended exponent length is shorter, which makes DH key exchange more efficient. Beware that with such DSA-style DH parameters, a fresh DH key should be created for each use to avoid small-subgroup attacks that may be possible otherwise.
```

[Related SO thread](https://security.stackexchange.com/a/95184)