### PR TITLE
ci: fix snyk sbom [DO-2367]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test SBOM generation
-        run: snyk sbom --file=./node-runner-cli/Pipfile --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json --json-file-output sbom.json
+        run: snyk sbom --file=./node-runner-cli/Pipfile --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json > sbom.json
 
   snyk-monitor:
     runs-on: ubuntu-latest
@@ -136,7 +136,7 @@ jobs:
           snyk -v
           snyk auth ${{ env.SNYK_TOKEN }}
       - name: Generate SBOM
-        run: snyk sbom --file=./node-runner-cli/Pipfile --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json --json-file-output sbom.json
+        run: snyk sbom --file=./node-runner-cli/Pipfile --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json > sbom.json
       - name: Upload SBOM
         uses: RDXWorks-actions/action-gh-release@master
         with:


### PR DESCRIPTION
`--json-file-output` parameter stopped working properly but the same effect can be achieved with stdout redirect `>`